### PR TITLE
Prevent crashes of Firefox inside a Docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ image:
 	docker image build -t $(IMAGE_LABEL) .
 
 run:
-	docker run --rm --env-file $(ENV_FILE) --name $(CONTAINER_NAME) $(IMAGE_LABEL) 2>&1 | tee $(CONTAINER_NAME).log
+	docker run --rm --shm-size 2g --env-file $(ENV_FILE) --name $(CONTAINER_NAME) $(IMAGE_LABEL) 2>&1 | tee $(CONTAINER_NAME).log
 
 .PHONY: all image run


### PR DESCRIPTION
To prevent crashes of Firefox inside a Docker container, added the "--shm-size 2g" argument.

This will increase the size of shared memory located at /dev/shm.
By default, the size of /dev/shm is 64MB, which is not enough.
2GB is an arbitrary value known to work well.

*Issue #, if available:*

*Description of changes:*
Issue on the Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1338771#c10
Explanation in docker-firefox repository: https://github.com/jlesage/docker-firefox/blob/master/README.md#increasing-shared-memory-size

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
