### PR TITLE
Removed Firefox Doorhanger Notification & Added documentation support for Chime SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ You will need Docker and `make` installed on your system. As this container is r
 
 The input for the container is a file called `container.env`. You create this file by copying the `container.env.template` to `container.env` and filling in the following variables:
  
-* `MEETING_PIN`: the PIN for the Amazon Chime meeting you wish to broadcast (without any spaces in it)
-  * Example: `1234567890`
+ 
+* `MEETING_URL`: Chime Meeting URL (without any spaces in it)
+  * Example(If you want to record Chime): ` https://app.chime.aws/portal/<your Meeting ID here>`
+  * Example(For Chime SDK Demo Users): `<Hosted Chime URL>/?m=<Meeting ID>&record=true`
 * `RTMP_URL`: the URL of the RTMP endpoint,
   * Twitch example: `rtmp://live.twitch.tv/app/<stream key>`
   * YouTube Live example: `rtmp://a.rtmp.youtube.com/live2/<stream key>`

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The input for the container is a file called `container.env`. You create this fi
  
  
 * `MEETING_URL`: Chime Meeting URL (without any spaces in it)
-  * Example(If you want to record Chime): ` https://app.chime.aws/portal/<your Meeting ID here>`
-  * Example(For Chime SDK Demo Users): `<Hosted Chime URL>/?m=<Meeting ID>&record=true`
+  * Example(If you want to record Chime): `https://app.chime.aws/portal/<your Meeting ID here>`
+  * Example(Hosted Chime SDK Demo URL): `<Hosted Chime URL>/?m=<Meeting ID>&record=true`
 * `RTMP_URL`: the URL of the RTMP endpoint,
   * Twitch example: `rtmp://live.twitch.tv/app/<stream key>`
   * YouTube Live example: `rtmp://a.rtmp.youtube.com/live2/<stream key>`

--- a/container.env.template
+++ b/container.env.template
@@ -1,2 +1,2 @@
-MEETING_PIN=<meeting PIN>
+MEETING_URL=<meeting URL>
 RTMP_URL=rtmp://live.twitch.tv/app/<Twitch stream key>

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BROWSER_URL=https://app.chime.aws/portal/${MEETING_PIN}
+BROWSER_URL=${MEETING_URL}
 SCREEN_WIDTH=1920
 SCREEN_HEIGHT=1080
 SCREEN_RESOLUTION=${SCREEN_WIDTH}x${SCREEN_HEIGHT}
@@ -43,6 +43,7 @@ user_pref("media.navigator.permission.disabled", true);
 user_pref("media.gmp-gmpopenh264.abi", "x86_64-gcc3");
 user_pref("media.gmp-gmpopenh264.lastUpdate", 1571534329);
 user_pref("media.gmp-gmpopenh264.version", "1.8.1.1");
+user_pref("doh-rollout.doorhanger-shown", true);
 EOF
 
 # Start Firefox browser and point it at the URL we want to capture


### PR DESCRIPTION
… Demos

Removed Firefox Doorhanger Notification & Added support for Chime SDK Demos

*Issue #, if available:*
- Firefox notifications shows up on video broadcasting
- Adding support for Chime SDK

*Description of changes:*
Removed Firefox Doorhanger Notification & Added support for Chime SDK Demos

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
