### PR TITLE
Update Chime SDK Serverless Demo URL to include `broadcast=true` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The input for the container is a file called `container.env`. You create this fi
  
 * `MEETING_URL`: Chime Meeting URL (without any spaces in it)
   * Example(If you want to record Chime): `https://app.chime.aws/portal/<your Meeting ID here>`
-  * Example(Hosted Chime SDK Demo URL): `<Hosted Chime URL>/?m=<Meeting ID>&record=true`
+  * Example(Hosted [Chime SDK Serverless Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless) URL): `<Hosted Chime URL>/?m=<Meeting ID>&broadcast=true`
 * `RTMP_URL`: the URL of the RTMP endpoint,
   * Twitch example: `rtmp://live.twitch.tv/app/<stream key>`
   * YouTube Live example: `rtmp://a.rtmp.youtube.com/live2/<stream key>`


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*
Update Chime SDK Serverless Demo URL to include `broadcast=true` in README

Corresponding changes in the serverless demo: https://github.com/aws/amazon-chime-sdk-js/pull/510

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
