### PR TITLE
Hide microphone logo

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -46,6 +46,11 @@ user_pref("media.gmp-gmpopenh264.version", "1.8.1.1");
 user_pref("doh-rollout.doorhanger-shown", true);
 EOF
 
+# Hide microphone logo
+cat <<EOF >> /tmp/foo4/prefs.js
+user_pref("privacy.webrtc.legacyGlobalIndicator", false);
+EOF
+
 # Start Firefox browser and point it at the URL we want to capture
 #
 # NB: The `--width` and `--height` arguments have to be very early in the


### PR DESCRIPTION
As promised in https://github.com/aws-samples/amazon-chime-live-events/pull/36